### PR TITLE
Postgres Support for ISS Key Storage

### DIFF
--- a/resources/sql_scripts/CVManager_CreateTables.sql
+++ b/resources/sql_scripts/CVManager_CreateTables.sql
@@ -324,6 +324,21 @@ SELECT ro.rsu_id, org.name
 FROM public.rsu_organization AS ro
 JOIN public.organizations AS org ON ro.organization_id = org.organization_id;
 
+-- Create iss keys table (id, iss_key, creation_date, expiration_date)
+CREATE SEQUENCE public.iss_keys_iss_key_id_seq
+   INCREMENT 1
+   START 1
+   MINVALUE 1
+   MAXVALUE 2147483647
+   CACHE 1;
+
+CREATE TABLE IF NOT EXISTS public.iss_keys
+(
+   iss_key_id integer NOT NULL DEFAULT nextval('iss_keys_iss_key_id_seq'::regclass),
+   common_name character varying(128) COLLATE pg_catalog.default NOT NULL,
+   token character varying(128) COLLATE pg_catalog.default NOT NULL
+);
+
 -- Create scms_health table
 CREATE SEQUENCE public.scms_health_scms_health_id_seq
    INCREMENT 1

--- a/services/addons/images/iss_health_check/README.md
+++ b/services/addons/images/iss_health_check/README.md
@@ -11,15 +11,15 @@
 
 This directory contains a microservice that runs within the CV Manager GKE Cluster. The iss_health_checker application populates the CV Manager PostGreSQL database's 'scms_health' table with the current ISS SCMS statuses of all RSUs recorded in the 'rsus' table. These statuses are queried by this application from a provided ISS Green Hills SCMS API endpoint.
 
-The application schedules the iss_health_checker script to run every 6 hours. A new SCMS API access key is generated every run of the script to ensure the access never expires. This is due to a limitation of the SCMS API not allowing permanent access keys. Access keys are stored in GCP Secret Manager to allow for versioning and encrypted storage. The application removes the previous access key from the SCMS API after runtime to reduce clutter of access keys on the API service account.
+The application schedules the iss_health_checker script to run every 6 hours. A new SCMS API access key is generated every run of the script to ensure the access never expires. This is due to a limitation of the SCMS API not allowing permanent access keys. Access keys can be stored in GCP Secret Manager to allow for versioning and encrypted storage. The application removes the previous access key from the SCMS API after runtime to reduce clutter of access keys on the API service account.
 
-Currently only GCP is supported to run this application due to a reliance on the GCP Secret Manager. Storing the access keys on a local volume is not recommended due to security vulnerabilities. Feel free to contribute to this application for secret manager equivalent support for other cloud environments.
+Currently only GCP & Postgres are supported to run this application due to a reliance on the GCP Secret Manager. Storing the access keys on a local volume is not recommended due to security vulnerabilities. Feel free to contribute to this application to support other storage solutions.
 
 ## Requirements <a name = "requirements"></a>
 
 To properly run the iss_health_checker microservice the following services are also required:
 
-- GCP project and service account with GCP Secret Manager access
+- GCP project and service account with GCP Secret Manager access (only required if STORAGE_TYPE is set to 'gcp')
 - CV Manager PostgreSQL database with at least one RSU inserted into the 'rsus' table
 - Service agreement with ISS Green Hills to have access to the SCMS API REST service endpoint
 - iss_health_checker must be deployed in the same environment or K8s cluster as the PostgreSQL database
@@ -27,7 +27,9 @@ To properly run the iss_health_checker microservice the following services are a
 
 The iss_health_checker microservice expects the following environment variables to be set:
 
-- GOOGLE_APPLICATION_CREDENTIALS - file location for GCP JSON service account key.
+- STORAGE_TYPE - Storage solution for the SCMS API access keys. Currently only 'gcp' & 'postgres' are supported.
+- GOOGLE_APPLICATION_CREDENTIALS - File location for GCP JSON service account key. Only required if STORAGE_TYPE is set to 'gcp'.
+- ISS_KEY_TABLE_NAME - Postgres table name for the ISS SCMS API access keys. Only required if STORAGE_TYPE is set to 'postgres'.
 - PROJECT_ID - GCP project ID.
 - ISS_API_KEY - Initial ISS SCMS API access key to perform the first run of the script. This access key must not expire before the first runtime.
 - ISS_API_KEY_NAME - Human readable reference for the access key within ISS SCMS API. Generated access keys will utilize this same name.

--- a/services/addons/images/iss_health_check/README.md
+++ b/services/addons/images/iss_health_check/README.md
@@ -13,7 +13,7 @@ This directory contains a microservice that runs within the CV Manager GKE Clust
 
 The application schedules the iss_health_checker script to run every 6 hours. A new SCMS API access key is generated every run of the script to ensure the access never expires. This is due to a limitation of the SCMS API not allowing permanent access keys. Access keys can be stored in GCP Secret Manager to allow for versioning and encrypted storage. The application removes the previous access key from the SCMS API after runtime to reduce clutter of access keys on the API service account.
 
-Currently only GCP & Postgres are supported to run this application due to a reliance on the GCP Secret Manager. Storing the access keys on a local volume is not recommended due to security vulnerabilities. Feel free to contribute to this application to support other storage solutions.
+Currently GCP & Postgres are the only supported storage solutions to run this application. Storing the access keys on a local volume is not recommended due to security vulnerabilities. Feel free to contribute to this application to support other storage solutions.
 
 ## Requirements <a name = "requirements"></a>
 

--- a/services/addons/images/iss_health_check/iss_health_checker.py
+++ b/services/addons/images/iss_health_check/iss_health_checker.py
@@ -92,6 +92,12 @@ def insert_scms_data(data):
         'INSERT INTO public.scms_health("timestamp", health, expiration, rsu_id) VALUES'
     )
     for value in data.values():
+        try:
+            value["deviceHealth"]
+        except KeyError:
+            logging.warning("deviceHealth not found in data for RSU with id {}, is it real data?".format(value["rsu_id"]))
+            continue
+
         health = "1" if value["deviceHealth"] == "Healthy" else "0"
         if value["expiration"]:
             query = (

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -10,13 +10,19 @@ import logging
 def get_storage_type():
     """Get the storage type for the ISS SCMS API token
     """
+    try :
+        os.environ["STORAGE_TYPE"]
+    except KeyError:
+        logging.debug("STORAGE_TYPE environment variable not set, defaulting to gcp")
+        return "gcp"
+    
     if os.environ["STORAGE_TYPE"] == "gcp":
         return "gcp"
     elif os.environ["STORAGE_TYPE"] == "postgres":
         return "postgres"
     else:
         # default to gcp
-        logging.debug("STORAGE_TYPE environment variable not set, defaulting to gcp")
+        logging.debug("STORAGE_TYPE environment variable not recognized, defaulting to gcp")
         return "gcp"
 
 

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -16,9 +16,10 @@ def get_storage_type():
         logging.error("STORAGE_TYPE environment variable not set, exiting")
         exit(1)
     
-    if os.environ["STORAGE_TYPE"] == "gcp":
+    storageTypeCaseInsensitive = os.environ["STORAGE_TYPE"].casefold()
+    if storageTypeCaseInsensitive == "gcp":
         return "gcp"
-    elif os.environ["STORAGE_TYPE"] == "postgres":
+    elif storageTypeCaseInsensitive == "postgres":
         return "postgres"
     else:
         logging.error("STORAGE_TYPE environment variable not set to a valid value, exiting")

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -13,17 +13,16 @@ def get_storage_type():
     try :
         os.environ["STORAGE_TYPE"]
     except KeyError:
-        logging.debug("STORAGE_TYPE environment variable not set, defaulting to gcp")
-        return "gcp"
+        logging.error("STORAGE_TYPE environment variable not set, exiting")
+        exit(1)
     
     if os.environ["STORAGE_TYPE"] == "gcp":
         return "gcp"
     elif os.environ["STORAGE_TYPE"] == "postgres":
         return "postgres"
     else:
-        # default to gcp
-        logging.debug("STORAGE_TYPE environment variable not recognized, defaulting to gcp")
-        return "gcp"
+        logging.error("STORAGE_TYPE environment variable not set to a valid value, exiting")
+        exit(1)
 
 
 # GCP Secret Manager functions

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -1,11 +1,26 @@
 from google.cloud import secretmanager
+import common.pgquery as pgquery
 import requests
 import os
 import json
 import uuid
 import logging
 
+# Get storage type from environment variable
+def get_storage_type():
+    """Get the storage type for the ISS SCMS API token
+    """
+    if os.environ["STORAGE_TYPE"] == "gcp":
+        return "gcp"
+    elif os.environ["STORAGE_TYPE"] == "postgres":
+        return "postgres"
+    else:
+        # default to gcp
+        logging.debug("STORAGE_TYPE environment variable not set, defaulting to gcp")
+        return "gcp"
 
+
+# GCP Secret Manager functions
 def create_secret(client, secret_id, parent):
     """Create a new GCP secret in GCP Secret Manager
     client: GCP Security Manager client
@@ -66,26 +81,89 @@ def add_secret_version(client, secret_id, parent, data):
     logging.debug("New version added")
 
 
-def get_token():
-    client = secretmanager.SecretManagerServiceClient()
-    secret_id = "iss-token-secret"
-    parent = f"projects/{os.environ['PROJECT_ID']}"
-
-    # Check to see if the GCP secret exists
-    secret_exists = check_if_secret_exists(client, secret_id, parent)
-
-    if secret_exists:
-        # Grab the latest token data
-        value = get_latest_secret_version(client, secret_id, parent)
-        friendly_name = value["name"]
-        token = value["token"]
-        logging.debug(f"Received token: {friendly_name}")
+# Postgres functions
+def check_if_data_exists(table_name):
+    """Check if data exists in the table
+    table_name: name of the table
+    """
+    # create the query
+    query = f"SELECT * FROM {table_name}"
+    # execute the query
+    data = pgquery.query_db(query)
+    # check if data exists
+    if len(data) > 0:
+        return True
     else:
-        # If there is no available ISS token secret, create secret
-        logging.debug("Secret does not exist, creating secret")
-        create_secret(client, secret_id, parent)
-        # Use environment variable for first run with new secret
-        token = os.environ["ISS_API_KEY"]
+        return False
+
+
+def get_latest_data(table_name):
+    """Get latest value of a token from the table
+    table_name: name of the table
+    """
+    # create the query
+    query = f"SELECT * FROM {table_name} ORDER BY iss_key_id DESC LIMIT 1"
+    # execute the query
+    data = pgquery.query_db(query)
+    # return the data
+    toReturn = {}
+    toReturn["id"] = data[0][0] # id
+    toReturn["name"] = data[0][1] # common_name
+    toReturn["token"] = data[0][2] # token
+    logging.debug(f"Received token: {toReturn['name']} with id {toReturn['id']}")
+    return toReturn
+
+
+def add_data(table_name, common_name, token):
+    """Add a new token to the table
+    table_name: name of the table
+    data: String value for the new token
+    """
+    # create the query
+    query = f"INSERT INTO {table_name} (common_name, token) VALUES ('{common_name}', '{token}')"
+    # execute the query
+    pgquery.write_db(query)
+
+
+# Main function
+def get_token():
+    storage_type = get_storage_type()
+    if storage_type == "gcp":
+        client = secretmanager.SecretManagerServiceClient()
+        secret_id = "iss-token-secret"
+        parent = f"projects/{os.environ['PROJECT_ID']}"
+
+        # Check to see if the GCP secret exists
+        data_exists = check_if_secret_exists(client, secret_id, parent)
+
+        if data_exists:
+            # Grab the latest token data
+            value = get_latest_secret_version(client, secret_id, parent)
+            friendly_name = value["name"]
+            token = value["token"]
+            logging.debug(f"Received token: {friendly_name}")
+        else:
+            # If there is no available ISS token secret, create secret
+            logging.debug("Secret does not exist, creating secret")
+            create_secret(client, secret_id, parent)
+            # Use environment variable for first run with new secret
+            token = os.environ["ISS_API_KEY"]
+    elif storage_type == "postgres":
+        key_table_name = os.environ["ISS_KEY_TABLE_NAME"]
+        
+        # check to see if data exists in the table
+        data_exists = check_if_data_exists(key_table_name)
+
+        if data_exists:
+            # grab the latest token data
+            value = get_latest_data(key_table_name)
+            id = value["id"]
+            friendly_name = value["name"]
+            token = value["token"]
+            logging.debug(f"Received token: {friendly_name} with id {id}")
+        else:
+            # if there is no data, use environment variable for first run
+            token = os.environ["ISS_API_KEY"]
 
     # Pull new ISS SCMS API token
     iss_base = os.environ["ISS_SCMS_TOKEN_REST_ENDPOINT"]
@@ -103,7 +181,7 @@ def get_token():
     new_token = response.json()["Item"]
     logging.debug(f"Received new token: {new_friendly_name}")
 
-    if secret_exists:
+    if data_exists:
         # If exists, delete previous API key to prevent key clutter
         iss_delete_body = {"friendlyName": friendly_name}
         requests.delete(iss_base, json=iss_delete_body, headers=iss_headers)
@@ -111,6 +189,11 @@ def get_token():
 
     version_data = {"name": new_friendly_name, "token": new_token}
 
-    add_secret_version(client, secret_id, parent, version_data)
+    if get_storage_type() == "gcp":
+        # Add new version to the secret
+        add_secret_version(client, secret_id, parent, version_data)
+    elif get_storage_type() == "postgres":
+        # add new entry to the table
+        add_data(key_table_name, new_friendly_name, new_token)
 
     return new_token

--- a/services/addons/images/iss_health_check/sample.env
+++ b/services/addons/images/iss_health_check/sample.env
@@ -12,9 +12,19 @@ PG_DB_NAME=
 PG_DB_USER=
 PG_DB_PASS=
 
-# GCP Project ID and service account JSON key file location (mount as volume or secret)
+# Key Storage
+## Type of key storage, options: gcp, postgres
+STORAGE_TYPE=
+
+## GCP Storage (Required if STORAGE_TYPE=gcp)
+### GCP Project ID
 PROJECT_ID=
+### Service account JSON key file location (mount as volume or secret)
 GOOGLE_APPLICATION_CREDENTIALS=
+
+## Postgres Storage (Required if STORAGE_TYPE=postgres)
+### Table name to store keys
+ISS_KEY_TABLE_NAME=
 
 # Customize the logging level, defaults to INFO
 # Options: DEBUG, INFO, WARN, ERROR (case sensitive)

--- a/services/addons/tests/iss_health_check/test_iss_token.py
+++ b/services/addons/tests/iss_health_check/test_iss_token.py
@@ -34,9 +34,11 @@ def test_get_storage_type_postgres():
     },
 )
 def test_get_storage_type_invalid():
-    expected_default = "gcp"
-    actual_value = iss_token.get_storage_type()
-    assert actual_value == expected_default
+    try:
+        iss_token.get_storage_type()
+        assert False
+    except SystemExit:
+        assert True
 
 
 @patch.dict(
@@ -46,9 +48,11 @@ def test_get_storage_type_invalid():
     },
 )
 def test_get_storage_type_unset():
-    expected_default = "gcp"
-    actual_value = iss_token.get_storage_type()
-    assert actual_value == expected_default
+    try:
+        iss_token.get_storage_type()
+        assert False
+    except SystemExit:
+        assert True
 
 # --------------------- end of Storage Type tests ---------------------
     

--- a/services/addons/tests/iss_health_check/test_iss_token.py
+++ b/services/addons/tests/iss_health_check/test_iss_token.py
@@ -98,6 +98,7 @@ def test_add_secret_version(mock_sm_client):
         "ISS_API_KEY": "test-api-key",
         "ISS_SCMS_TOKEN_REST_ENDPOINT": "https://api.dm.iss-scms.com/api/test-token",
         "ISS_API_KEY_NAME": "test-api-key-name",
+        "STORAGE_TYPE": "gcp",
     },
 )
 @patch("addons.images.iss_health_check.iss_token.requests.Response")
@@ -162,6 +163,7 @@ def test_get_token_create_secret(
         "ISS_API_KEY": "test-api-key",
         "ISS_SCMS_TOKEN_REST_ENDPOINT": "https://api.dm.iss-scms.com/api/test-token",
         "ISS_API_KEY_NAME": "test-api-key-name",
+        "STORAGE_TYPE": "gcp",
     },
 )
 @patch("addons.images.iss_health_check.iss_token.requests.Response")

--- a/services/addons/tests/iss_health_check/test_iss_token.py
+++ b/services/addons/tests/iss_health_check/test_iss_token.py
@@ -27,6 +27,29 @@ def test_get_storage_type_postgres():
     actual_value = iss_token.get_storage_type()
     assert actual_value == "postgres"
 
+
+@patch.dict(
+    os.environ,
+    {
+        "STORAGE_TYPE": "GCP",
+    },
+)
+def test_get_storage_type_gcp_case_insensitive():
+    actual_value = iss_token.get_storage_type()
+    assert actual_value == "gcp"
+
+
+@patch.dict(
+    os.environ,
+    {
+        "STORAGE_TYPE": "POSTGRES",
+    },
+)
+def test_get_storage_type_postgres_case_insensitive():
+    actual_value = iss_token.get_storage_type()
+    assert actual_value == "postgres"
+
+
 @patch.dict(
     os.environ,
     {


### PR DESCRIPTION
## Problem
The ISS Health Checker is currently only capable of using GCP to store its keys.

## Solution
Support has been added for storing keys using the existing PGSQL database instead of GCP.

## Testing
- Unit tests for postgres storage were added & verified to be passing
- This has been deployed on WYDOT's Test VM and the logs indicate it is working.