### PR TITLE
Docker Storage Support for the Firmware Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cov.xml
 cov_html
 htmlcov
 .pytest_cache
+local_blob_storage

--- a/docker-compose-addons.yml
+++ b/docker-compose-addons.yml
@@ -89,6 +89,7 @@ services:
       LOGGING_LEVEL: ${API_LOGGING_LEVEL}
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS}:/google/gcp_credentials.json
+      - ${HOST_BLOB_STORAGE_DIRECTORY}:/mnt/blob_storage
     logging:
       options:
         max-size: '10m'

--- a/sample.env
+++ b/sample.env
@@ -87,9 +87,12 @@ MAPBOX_INIT_LONGITUDE="-104.9903"
 MAPBOX_INIT_ZOOM="10"
 
 # Firmware Manager
-BLOB_STORAGE_PROVIDER=GCP
-BLOB_STORAGE_BUCKET=
+BLOB_STORAGE_PROVIDER=DOCKER
+# GCP Project and Bucket for BLOB storage (if using GCP)
 GCP_PROJECT=
+BLOB_STORAGE_BUCKET=
+# Docker volume mount point for BLOB storage (if using Docker)
+HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # Levels are "DEBUG", "INFO", "WARNING", and "ERROR"
 API_LOGGING_LEVEL="INFO"

--- a/sample.env
+++ b/sample.env
@@ -87,11 +87,12 @@ MAPBOX_INIT_LONGITUDE="-104.9903"
 MAPBOX_INIT_ZOOM="10"
 
 # Firmware Manager
+## Provider of storage for firmware files (currently supported: GCP, DOCKER)
 BLOB_STORAGE_PROVIDER=DOCKER
-# GCP Project and Bucket for BLOB storage (if using GCP)
+## GCP Project and Bucket for BLOB storage (if using GCP)
 GCP_PROJECT=
 BLOB_STORAGE_BUCKET=
-# Docker volume mount point for BLOB storage (if using Docker)
+## Docker volume mount point for BLOB storage (if using Docker)
 HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # Levels are "DEBUG", "INFO", "WARNING", and "ERROR"

--- a/services/addons/images/firmware_manager/README.md
+++ b/services/addons/images/firmware_manager/README.md
@@ -16,7 +16,7 @@ This directory contains a microservice that runs within the CV Manager GKE Clust
 
 An RSU is determined to be ready for upgrade if its entry in the "rsus" table in PostgreSQL has its "target_firmware_version" set to be different than its "firmware_version". The Firmware Manager will ignore all devices with incompatible firmware upgrades set as their target firmware based on the "firmware_upgrade_rules" table. The CV Manager API will only offer CV Manager webapp users compatible options so this generally is a precaution.
 
-Hosting firmware files is recommended to be done via the cloud. GCP cloud storage is the currently supported method. Alternatives can be added via the [download_blob.py](download_blob.py) script. Firmware storage must be organized by: `vendor/rsu-model/firmware-version/install_package`.
+Hosting firmware files is recommended to be done via the cloud. GCP cloud storage is the currently supported method, but a directory mounted as a docker volume can also be used. Alternative cloud support can be added via the [download_blob.py](download_blob.py) script. Firmware storage must be organized by: `vendor/rsu-model/firmware-version/install_package`.
 
 Firmware upgrades have unique procedures based on RSU vendor/manufacturer. To avoid requiring a unique bash script for every single firmware upgrade, the Firmware Manager has been written to use vendor based upgrade scripts that have been thoroughly tested. An interface-like abstract class, [base_upgrader.py](base_upgrader.py), has been made for helping create upgrade scripts for vendors not yet supported. The Firmware Manager selects the script to use based off the RSU's "model" column in the "rsus" table. These scripts report back to the Firmware Manager on completion with a status of whether the upgrade was a success or failure. Regardless, the Firmware Manager will remove the process from its tracking and update the PostgreSQL database accordingly.
 
@@ -40,7 +40,7 @@ Available REST endpoints:
 
 To properly run the firmware_manager microservice the following services are also required:
 
-- Cloud based blob storage
+- Cloud based blob storage (if not using a directory mounted as a docker volume)
   - Firmware storage must be organized by: `vendor/rsu-model/firmware-version/install_package`.
 - CV Manager PostgreSQL database with data in the "rsus", "rsu_models", "manufacturers", "firmware_images", and "firmware_upgrade_rules" tables
 - Network connectivity from the environment the firmware_manager is deployed into to the blob storage and the RSUs
@@ -59,6 +59,9 @@ GCP Required environment variables:
 
 - GCP_PROJECT - GCP project for the firmware cloud storage bucket
 - GOOGLE_APPLICATION_CREDENTIALS - Service account location. Recommended to attach as a volume.
+
+Docker volume required environment variables:
+- HOST_BLOB_STORAGE_DIRECTORY - Directory mounted as a docker volume for firmware storage
 
 ## Vendor Specific Requirements
 

--- a/services/addons/images/firmware_manager/README.md
+++ b/services/addons/images/firmware_manager/README.md
@@ -40,7 +40,7 @@ Available REST endpoints:
 
 To properly run the firmware_manager microservice the following services are also required:
 
-- Cloud based blob storage (if not using a directory mounted as a docker volume)
+- Blob storage (cloud-based or otherwise)
   - Firmware storage must be organized by: `vendor/rsu-model/firmware-version/install_package`.
 - CV Manager PostgreSQL database with data in the "rsus", "rsu_models", "manufacturers", "firmware_images", and "firmware_upgrade_rules" tables
 - Network connectivity from the environment the firmware_manager is deployed into to the blob storage and the RSUs
@@ -61,7 +61,7 @@ GCP Required environment variables:
 - GOOGLE_APPLICATION_CREDENTIALS - Service account location. Recommended to attach as a volume.
 
 Docker volume required environment variables:
-- HOST_BLOB_STORAGE_DIRECTORY - Directory mounted as a docker volume for firmware storage
+- HOST_BLOB_STORAGE_DIRECTORY - Directory mounted as a docker volume for firmware storage. A relative path can be specified here.
 
 ## Vendor Specific Requirements
 

--- a/services/addons/images/firmware_manager/download_blob.py
+++ b/services/addons/images/firmware_manager/download_blob.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 
-# Only supports GCP Bucket Storage for downloading blobs
+# Download a blob from GCP Bucket Storage
 def download_gcp_blob(blob_name, destination_file_name):
     gcp_project = os.environ.get("GCP_PROJECT")
     bucket_name = os.environ.get("BLOB_STORAGE_BUCKET")
@@ -13,4 +13,14 @@ def download_gcp_blob(blob_name, destination_file_name):
     blob.download_to_filename(destination_file_name)
     logging.info(
         f"Downloaded storage object {blob_name} from bucket {bucket_name} to local file {destination_file_name}."
+    )
+
+
+# "Download" a blob from a directory mounted as a volume in a Docker container
+def download_docker_blob(blob_name, destination_file_name):
+    directory = "/mnt/blob_storage"
+    source_file_name = f"{directory}/{blob_name}"
+    os.system(f"cp {source_file_name} {destination_file_name}")
+    logging.info(
+        f"Copied storage object {blob_name} from directory {directory} to local file {destination_file_name}."
     )

--- a/services/addons/images/firmware_manager/sample.env
+++ b/services/addons/images/firmware_manager/sample.env
@@ -7,8 +7,12 @@ PG_DB_USER=""
 PG_DB_PASS=""
 
 # Blob storage variables
-BLOB_STORAGE_PROVIDER="GCP"
-BLOB_STORAGE_BUCKET=""
+BLOB_STORAGE_PROVIDER=DOCKER
+# GCP Project and Bucket for BLOB storage (if using GCP)
+GCP_PROJECT=
+BLOB_STORAGE_BUCKET=
+# Docker volume mount point for BLOB storage (if using Docker)
+HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # For users using GCP cloud storage
 GCP_PROJECT=""

--- a/services/addons/images/firmware_manager/sample.env
+++ b/services/addons/images/firmware_manager/sample.env
@@ -8,10 +8,10 @@ PG_DB_PASS=""
 
 # Blob storage variables
 BLOB_STORAGE_PROVIDER=DOCKER
-# GCP Project and Bucket for BLOB storage (if using GCP)
+## GCP Project and Bucket for BLOB storage (if using GCP)
 GCP_PROJECT=
 BLOB_STORAGE_BUCKET=
-# Docker volume mount point for BLOB storage (if using Docker)
+## Docker volume mount point for BLOB storage (if using Docker)
 HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # For users using GCP cloud storage

--- a/services/addons/images/firmware_manager/upgrader.py
+++ b/services/addons/images/firmware_manager/upgrader.py
@@ -33,9 +33,11 @@ class UpgraderAbstractClass(abc.ABC):
         Path(path).mkdir(exist_ok=True)
 
         # Download blob, defaults to GCP blob storage
-        bsp = os.environ.get("BLOB_STORAGE_PROVIDER", "GCP")
-        if bsp == "GCP":
+        bspCaseInsensitive = os.environ.get("BLOB_STORAGE_PROVIDER", "DOCKER").casefold()
+        if bspCaseInsensitive == "gcp":
             download_blob.download_gcp_blob(self.blob_name, self.local_file_name)
+        elif bspCaseInsensitive == "docker":
+            download_blob.download_docker_blob(self.blob_name, self.local_file_name)
         else:
             logging.error("Unsupported blob storage provider")
 

--- a/services/addons/tests/firmware_manager/test_download_blob.py
+++ b/services/addons/tests/firmware_manager/test_download_blob.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import os
 
 from addons.images.firmware_manager import download_blob
@@ -28,3 +28,21 @@ def test_download_gcp_blob(mock_storage_client, mock_logging):
     mock_logging.info.assert_called_with(
         "Downloaded storage object test.blob from bucket test-bucket to local file /home/test/."
     )
+
+
+@patch("addons.images.firmware_manager.download_blob.logging")
+def test_download_docker_blob(mock_logging):
+    # prepare
+    os.system = MagicMock()
+    blob_name = "test.blob"
+    destination_file_name = "/home/test/"
+
+    # run
+    download_blob.download_docker_blob(blob_name, destination_file_name)
+
+    # validate
+    os.system.assert_called_with(f"cp /mnt/blob_storage/{blob_name} {destination_file_name}")
+    mock_logging.info.assert_called_with(
+        f"Copied storage object {blob_name} from directory /mnt/blob_storage to local file {destination_file_name}."
+    )
+

--- a/services/addons/tests/firmware_manager/test_upgrader.py
+++ b/services/addons/tests/firmware_manager/test_upgrader.py
@@ -85,6 +85,21 @@ def test_download_blob_gcp(mock_Path, mock_download_gcp_blob):
         "/home/8.8.8.8/firmware_package.tar",
     )
 
+@patch.dict(os.environ, {"BLOB_STORAGE_PROVIDER": "DOCKER"})
+@patch("addons.images.firmware_manager.upgrader.download_blob.download_docker_blob")
+@patch("addons.images.firmware_manager.upgrader.Path")
+def test_download_blob_docker(mock_Path, mock_download_docker_blob):
+    mock_path_obj = mock_Path.return_value
+    test_upgrader = TestUpgrader(test_upgrade_info)
+
+    test_upgrader.download_blob()
+
+    mock_path_obj.mkdir.assert_called_with(exist_ok=True)
+    mock_download_docker_blob.assert_called_with(
+        "test-manufacturer/test-model/1.0.0/firmware_package.tar",
+        "/home/8.8.8.8/firmware_package.tar",
+    )
+
 
 @patch.dict(os.environ, {"BLOB_STORAGE_PROVIDER": "Test"})
 @patch("addons.images.firmware_manager.upgrader.logging")


### PR DESCRIPTION
## Problem
The Firmware Manager addon currently only supports storing firmware files in GCP. In a deployment where this isn't desired, we need another way to store the firmware files.

## Solution
Support for storing firmware files in a directory mounted as a docker volume has been added to the project.

## Testing
- Unit tests pass with these changes.
- This has been deployed on WYDOT's Test VM.
- Program starts up correctly & checks for firmware upgrades as expected.
- Initiating a firmware upgrade for Trihydro's Test Bed RSU was successful.