### PR TITLE
Improved JSONDecodeError Handling for ISS Health Check

### DIFF
--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -184,7 +184,11 @@ def get_token():
     # Create new ISS SCMS API Token to ensure its freshness
     logging.debug("POST: " + iss_base)
     response = requests.post(iss_base, json=iss_post_body, headers=iss_headers)
-    new_token = response.json()["Item"]
+    try:
+        new_token = response.json()["Item"]
+    except requests.JSONDecodeError:
+        logging.error("Failed to decode JSON response from ISS SCMS API. Response: " + response.text)
+        exit(1)
     logging.debug(f"Received new token: {new_friendly_name}")
 
     if data_exists:


### PR DESCRIPTION
## Problem
Upon attempting to use expired credentials, the ISS Health Checker encounters a JSONDecodeError which results in a stack trace being logged.

## Solution
A try/except statement has been inserted to catch the JSONDecodeError, inform the user of the failure & print the response from ISS.

## Testing
This has been tested locally using docker-compose.