### PR TITLE
Accounted for new env vars in IHC manifest

### DIFF
--- a/resources/kubernetes/README.md
+++ b/resources/kubernetes/README.md
@@ -8,7 +8,7 @@ The webapp and API both utilize a K8s Ingress to handle external access to the a
 
 The YAML files use GCP specific specifications for various values such as "networking.gke.io/managed-certificates". These values will not work on AWS and Azure but there should be equivalent fields that these specifications can be updated to if needing to deploy in another cloud environment.
 
-The environment variables must be set according to the README documentation for each application. The iss-health-check application only supports GCP.
+The environment variables must be set according to the README documentation for each application. The iss-health-check application supports GCP or postgres for storing keys. The environment variables for the iss-health-check application must be set according to the README documentation for the iss-health-check application.
 
 ## Useful Links
 

--- a/resources/kubernetes/iss-health-check.yaml
+++ b/resources/kubernetes/iss-health-check.yaml
@@ -1,4 +1,4 @@
-# This deployment is only usable in a GCP environment due to the GCP Secret Manager dependency
+# If GCP is being used to store keys, this deployment will only be usable in a GCP environment due to the GCP Secret Manager dependency
 apiVersion: 'apps/v1'
 kind: 'Deployment'
 metadata:
@@ -27,6 +27,8 @@ spec:
           ports:
             - containerPort: 8080
           env:
+            - name: STORAGE_TYPE
+              value: GCP
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: '/home/secret/cv_credentials.json'
             - name: PROJECT_ID
@@ -40,6 +42,8 @@ spec:
             - name: ISS_SCMS_TOKEN_REST_ENDPOINT
               value: ''
             - name: ISS_SCMS_VEHICLE_REST_ENDPOINT
+              value: ''
+            - name: ISS_KEY_TABLE_NAME
               value: ''
             - name: DB_USER
               value: ''


### PR DESCRIPTION
## Problem
Some new environment variables were recently introduced to the ISS Health Checker addon, but these are not yet accounted for in the relevant manifest file.

## Solution
The manifest file for the ISS Health Checker addon has been modified to account for these new environment variables, and the README has been modified accordingly.

## Relevant PR Comment
This addresses the following PR comment: https://github.com/CDOT-CV/jpo-cvmanager/pull/33#issuecomment-1915711241