### PR TITLE
Used pytest.raises() instead of try/catch in `test_iss_token.py`

### DIFF
--- a/services/addons/tests/iss_health_check/test_iss_token.py
+++ b/services/addons/tests/iss_health_check/test_iss_token.py
@@ -2,6 +2,8 @@ from unittest.mock import patch, MagicMock
 import os
 import json
 
+import pytest
+
 from addons.images.iss_health_check import iss_token
 
 # --------------------- Storage Type tests ---------------------
@@ -57,11 +59,8 @@ def test_get_storage_type_postgres_case_insensitive():
     },
 )
 def test_get_storage_type_invalid():
-    try:
+    with pytest.raises(SystemExit):
         iss_token.get_storage_type()
-        assert False
-    except SystemExit:
-        assert True
 
 
 @patch.dict(
@@ -71,11 +70,8 @@ def test_get_storage_type_invalid():
     },
 )
 def test_get_storage_type_unset():
-    try:
+    with pytest.raises(SystemExit):
         iss_token.get_storage_type()
-        assert False
-    except SystemExit:
-        assert True
 
 # --------------------- end of Storage Type tests ---------------------
     


### PR DESCRIPTION
## Problem
We are using a try/catch solution to test exceptions in `test_iss_token.py`

## Solution
We have transitioned to using 'pytest.raises(exception)' instead of using try/catch blocks.

## Testing
Unit tests have been verified to pass with these changes.