### PR TITLE
Update multidict version to 6.0.5

### DIFF
--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -23,7 +23,7 @@ gunicorn==21.2.0
 pytz==2023.3.post1
 Werkzeug==3.0.0
 uuid==1.30
-multidict==6.0.4
+multidict==6.0.5
 python-keycloak==2.16.2
 fabric==3.2.2
 paramiko==3.3.1


### PR DESCRIPTION
## Problem
multidict 6.0.4 cannot be installed using Python 3.12.2

## Solution
The multidict dependency has been updated to 6.0.5

## Testing
Installing the dependencies into a virtual environment works and the unit tests pass.