### PR TITLE
Added default values of "true" for TLS & AUTH toggles

### DIFF
--- a/services/api/src/contact_support.py
+++ b/services/api/src/contact_support.py
@@ -38,8 +38,8 @@ class ContactSupportResource(Resource):
         self.CSM_TARGET_SMTP_SERVER_PORT = int(
             os.environ.get("CSM_TARGET_SMTP_SERVER_PORT")
         )
-        self.CSM_TLS_ENABLED = os.environ.get("CSM_TLS_ENABLED")
-        self.CSM_AUTH_ENABLED = os.environ.get("CSM_AUTH_ENABLED")
+        self.CSM_TLS_ENABLED = os.environ.get("CSM_TLS_ENABLED", "true")
+        self.CSM_AUTH_ENABLED = os.environ.get("CSM_AUTH_ENABLED", "true")
         self.CSM_EMAIL_APP_USERNAME = os.environ.get("CSM_EMAIL_APP_USERNAME")
         self.CSM_EMAIL_APP_PASSWORD = os.environ.get("CSM_EMAIL_APP_PASSWORD")
 
@@ -55,7 +55,7 @@ class ContactSupportResource(Resource):
         if not self.CSM_TARGET_SMTP_SERVER_PORT:
             logging.error("CSM_TARGET_SMTP_SERVER_PORT environment variable not set")
             abort(500)
-        
+
         if self.CSM_AUTH_ENABLED == "true":
             if not self.CSM_EMAIL_APP_USERNAME:
                 logging.error("CSM_EMAIL_APP_USERNAME environment variable not set")


### PR DESCRIPTION
## Problem
The current changes require changes to deployment files in order for the CV Manager to work. Instead we should have default values for new environment variables.

## Solution
The `CSM_TLS_ENABLED` and `CSM_AUTH_ENABLED` environment variables have default values of "true" now when not set.

## Testing
Unit tests were verified to pass with these changes.

## USDOT PR
This addresses a comment on https://github.com/usdot-jpo-ode/jpo-cvmanager/pull/22